### PR TITLE
Bareborns registry for encoders

### DIFF
--- a/topic_benchmark/__init__.py
+++ b/topic_benchmark/__init__.py
@@ -1,3 +1,4 @@
 from topic_benchmark.datasets import *
+from topic_benchmark.encoders import *
 from topic_benchmark.metrics import *
 from topic_benchmark.models import *

--- a/topic_benchmark/cli.py
+++ b/topic_benchmark/cli.py
@@ -3,14 +3,15 @@ import warnings
 from pathlib import Path
 from typing import Optional
 
+from catalogue import RegistryError
 from radicli import Arg, Radicli
 from sentence_transformers import SentenceTransformer
 
 from topic_benchmark.benchmark import BenchmarkEntry, run_benchmark
 from topic_benchmark.defaults import default_vectorizer
 from topic_benchmark.figures import produce_figures
-from topic_benchmark.table import produce_latex_table
 from topic_benchmark.registries import encoder_registry
+from topic_benchmark.table import produce_latex_table
 
 cli = Radicli()
 
@@ -26,13 +27,11 @@ def run_cli(
     vectorizer = default_vectorizer()
 
     print("Loading Encoder.")
-    # first try to load encoder from registry
-    # if not found, assume encoder is a sentence transformer
-    try:
-        encoder = encoder_registry.get(encoder_model)
-    except:
+    if encoder_model in encoder_registry:
+        encoder = encoder_registry.get(encoder_model)()
+    else:
         encoder = SentenceTransformer(encoder_model)
-        warnings.warn(
+        print(
             f"`{encoder_model}`: encoder model not found in registry. "
             "Loading using `SentenceTransformer`"
         )

--- a/topic_benchmark/encoders/__init__.py
+++ b/topic_benchmark/encoders/__init__.py
@@ -1,0 +1,1 @@
+from topic_benchmark.encoders.e5_encoders import *

--- a/topic_benchmark/encoders/e5_encoders.py
+++ b/topic_benchmark/encoders/e5_encoders.py
@@ -1,0 +1,27 @@
+"""
+Registry of E5 models
+"""
+
+from turftopic.encoders import E5Encoder
+
+from topic_benchmark.registries import encoder_registry
+
+
+@encoder_registry.register("intfloat/e5-large-v2")
+def create_e5_large_v2() -> E5Encoder:
+    hf_name = "intfloat/e5-large-v2"
+    return E5Encoder(model_name=hf_name, prefix="query: ")
+
+
+@encoder_registry.register("intfloat/multilingual-e5-small")
+def create_m_e5_small() -> E5Encoder:
+    hf_name = "intfloat/multilingual-e5-small"
+    return E5Encoder(model_name=hf_name, prefix="query: ")
+
+
+@encoder_registry.register("intfloat/multilingual-e5-large-instruct")
+def create_m_e5_large_instruct() -> E5Encoder:
+    hf_name = "intfloat/multilingual-e5-large-instruct"
+    task_description = "" #TODO
+    prefix = f"Instruct: {task_description} \nQuery: "
+    return E5Encoder(model_name=hf_name, prefix=prefix)

--- a/topic_benchmark/registries.py
+++ b/topic_benchmark/registries.py
@@ -3,3 +3,4 @@ import catalogue
 model_registry = catalogue.create("topic_benchmarks", "model_registry")
 metric_registry = catalogue.create("topic_benchmarks", "metric_registry")
 dataset_registry = catalogue.create("topic_benchmarks", "dataset_registry")
+encoder_registry = catalogue.create("topic_benchmarks", "encoder_registry")


### PR DESCRIPTION
Not to be merged in yet.

a) Is this the right direction with the encoder registry?
Can we use turtopic classes, or should there be a topic-benchmark base class for encoders?
PS [E5-KeyNMF encoder](https://github.com/x-tabdeveloping/turftopic/issues/23) will be added later.


b) The `encoder_registry` is empty.
Any idea WTF is going on?

Trying:
```
from topic_benchmark.registries import encoder_registry
print(encoder_registry.get_all())
```
Returns `{}`