### PR TITLE
Joint tables and figures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ line-length=79
 
 [tool.poetry]
 name = "topic-benchmark"
-version = "0.2.2"
+version = "0.2.3"
 description = "Benchmarking topic models for a paper"
 authors = ["Márton Kardos <power.up1163@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ gensim = "^4.3.2"
 radicli = "^0.0.25"
 pandas = "^2.1.0"
 plotly = "^5.18.0"
+kaleido="^0.2.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/topic_benchmark/cli.py
+++ b/topic_benchmark/cli.py
@@ -3,14 +3,15 @@ import warnings
 from pathlib import Path
 from typing import Optional
 
+from catalogue import RegistryError
 from radicli import Arg, Radicli
 from sentence_transformers import SentenceTransformer
 
 from topic_benchmark.benchmark import BenchmarkEntry, run_benchmark
 from topic_benchmark.defaults import default_vectorizer
 from topic_benchmark.figures import produce_figures
-from topic_benchmark.table import produce_latex_table
 from topic_benchmark.registries import encoder_registry
+from topic_benchmark.table import produce_latex_table
 
 cli = Radicli()
 
@@ -30,7 +31,7 @@ def run_cli(
     # if not found, assume encoder is a sentence transformer
     try:
         encoder = encoder_registry.get(encoder_model)
-    except:
+    except RegistryError:
         encoder = SentenceTransformer(encoder_model)
         warnings.warn(
             f"`{encoder_model}`: encoder model not found in registry. "

--- a/topic_benchmark/cli.py
+++ b/topic_benchmark/cli.py
@@ -27,11 +27,9 @@ def run_cli(
     vectorizer = default_vectorizer()
 
     print("Loading Encoder.")
-    # first try to load encoder from registry
-    # if not found, assume encoder is a sentence transformer
-    try:
+    if encoder_model in encoder_registry:
         encoder = encoder_registry.get(encoder_model)
-    except RegistryError:
+    else:
         encoder = SentenceTransformer(encoder_model)
         warnings.warn(
             f"`{encoder_model}`: encoder model not found in registry. "

--- a/topic_benchmark/cli.py
+++ b/topic_benchmark/cli.py
@@ -1,16 +1,19 @@
-import glob
 import json
 import warnings
 from pathlib import Path
 from typing import Optional
 
-from catalogue import RegistryError
+import pandas as pd
 from radicli import Arg, Radicli
 from sentence_transformers import SentenceTransformer
 
 from topic_benchmark.benchmark import BenchmarkEntry, run_benchmark
 from topic_benchmark.defaults import default_vectorizer
-from topic_benchmark.figures import produce_figures
+from topic_benchmark.figures import (
+    plot_nonalphabetical,
+    plot_speed,
+    plot_stop_words,
+)
 from topic_benchmark.registries import encoder_registry
 from topic_benchmark.table import produce_full_table
 
@@ -98,10 +101,42 @@ def make_table(
 
 @cli.command(
     "figures",
-    results_file=Arg(help="JSONL file containing benchmark results."),
+    results_folder=Arg(
+        help="Folder containing results for all embedding models."
+    ),
     out_dir=Arg(
         "--out_dir", "-o", help="Directory where the figures should be placed."
     ),
+    show_figures=Arg(
+        "--show_figures",
+        "-s",
+        help="Indicates whether the figures should be displayed in a browser tab or not.",
+    ),
 )
-def make_figures(results_file: str, out_dir: str = "figures"):
-    produce_figures(results_file, out_dir)
+def make_figures(
+    results_folder: str = "results/",
+    out_dir: str = "figures",
+    show_figures: bool = False,
+):
+    results_folder = Path(results_folder)
+    files = results_folder.glob("*.jsonl")
+    out_dir = Path(out_dir)
+    out_dir.mkdir(exist_ok=True)
+    dfs = []
+    for file in files:
+        file = Path(file)
+        df = pd.read_json(file, orient="records", lines=True)
+        df["encoder"] = file.stem.replace("__", "/")
+        dfs.append(df)
+    data = pd.concat(dfs)
+    figures = {
+        "n_nonalphabetical": plot_nonalphabetical,
+        "speed": plot_speed,
+        "stop_words": plot_stop_words,
+    }
+    for figure_name, produce in figures.items():
+        fig = produce(data)
+        out_path = out_dir.joinpath(f"{figure_name}.png")
+        fig.write_image(out_path, scale=2)
+        if show_figures:
+            fig.show()


### PR DESCRIPTION
Fixes #3 .
Both the `table` and the `figures` command now takes the whole results folder and produces joint figures and latex tables.
Additionally `figures` can now open all new figures in a browser tab if the `--show_figures` flag is added to the command.